### PR TITLE
"Create New" and "Whole Selection"

### DIFF
--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -3,5 +3,6 @@
 
 [
     { "keys": ["ctrl+e"], "command": "jump_to_interactive" },
-    { "keys": ["ctrl+shift+e"], "command": "jump_to_interactive", "args": { "extend": true } }
+    { "keys": ["ctrl+shift+e"], "command": "jump_to_interactive", "args": { "extend": true } },
+    { "keys": ["alt+e"], "command": "jump_to_interactive", "args": { "create_new": true } }
 ]

--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -3,6 +3,7 @@
 
 [
     { "keys": ["ctrl+e"], "command": "jump_to_interactive" },
-    { "keys": ["ctrl+shift+e"], "command": "jump_to_interactive", "args": { "extend": true } },
-    { "keys": ["alt+e"], "command": "jump_to_interactive", "args": { "create_new": true } }
+    { "keys": ["ctrl+shift+e"], "command": "jump_to_interactive", "args": { "extend": true, "whole_selection": true } },
+    { "keys": ["alt+e"], "command": "jump_to_interactive", "args": { "create_new": true } },
+    { "keys": ["ctrl+alt+e"], "command": "jump_to_interactive", "args": { "create_new": true, "whole_selection": true } }
 ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Summary
 
 JumpTo is a plugin for Sublime Text 2 to move the cursor to any position in the current line. It's very similar to some movement commands in Vim. This is especially useful when editing multiple similar lines at the same time.
 
-Watch [this video](http://vimeo.com/48392058) to see a real world example on how I use it to refactore some code.
+Watch [this video](http://vimeo.com/48392058) to see a real world example on how I use it to refactor some code.
 
 Install
 =======
@@ -17,6 +17,12 @@ Usage
 Press ctrl+e (or click on Goto -> Jump to) and enter a search string. The cursor will jump to the start of the first occurence of this search string.
 
 Press ctrl+shift+e (or click on Selection -> Expand Selection to) to select all characters from the current cursor position to the first occurence of the search string.
+
+Options
+========
+
+- __extend__: extend the current selection until the search result
+- __create_new__: True, if the current caret should stay and a new caret should be created at the target position
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Install
 Usage
 =====
 
-Press ctrl+e (or click on Goto -> Jump to) and enter a search string. The cursor will jump to the start of the first occurence of this search string.
+Press ctrl+e (or click on Goto -> Jump to) and enter a search string. The cursor will jump to the start of the first occurrence of this search string.
 
-Press ctrl+shift+e (or click on Selection -> Expand Selection to) to select all characters from the current cursor position to the first occurence of the search string.
+Press ctrl+shift+e (or click on Selection -> Expand Selection to) to select all characters from the current cursor position to the first occurrence of the search string.
 
 Options
 ========

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options
 
 - __extend__: extend the current selection until the search result
 - __create_new__: True, if the current caret should stay and a new caret should be created at the target position
+- __whole_selection__: Whether the command should result in a selection instead of a single caret
 
 License
 =======

--- a/jump_to.py
+++ b/jump_to.py
@@ -119,8 +119,13 @@ ADDREGIONS_FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_OUTLINED
 class JumpToInteractiveCommand(JumpToBase, sublime_plugin.WindowCommand):
     def run(self, characters="", extend=False, create_new=False):
         self._run(None, self.window.active_view(), extend, create_new)
-        text = "Expand selection" if extend else "Jump"
-        text += " to (chars or [chars] or {count} or /regex/):"
+        if extend:
+            text = "Expand selection to"
+        elif create_new:
+            text = "Create caret at"
+        else:
+            text = "Jump to"
+        text += " (chars or [chars] or {count} or /regex/):"
         self.window.show_input_panel(text, characters, self._on_enter, self._on_change, self._on_cancel)
 
     def _remove_highlight(self):

--- a/jump_to.py
+++ b/jump_to.py
@@ -22,8 +22,8 @@ class JumpToBase(object):
             self.view = view
 
     def find_next(self, chars, pt):
-        if chars == "":
-            return False
+        if not chars:
+            return
 
         lr = self.view.line(pt)
         line = self.view.substr(sublime.Region(pt, lr.b))
@@ -32,12 +32,10 @@ class JumpToBase(object):
         if idx >= 0:
             pt_start = pt + idx
             return sublime.Region(pt_start, pt_start + len(chars))
-        else:
-            return False
 
     def find_next_re(self, chars, pt):
-        if chars == "":
-            return False
+        if not chars:
+            return
 
         lr = self.view.line(pt)
         line = self.view.substr(sublime.Region(pt, lr.b))
@@ -45,24 +43,20 @@ class JumpToBase(object):
             result = re.search(chars, line)
         except:
             sublime.status_message("JumpTo: Error in regex !")
-            return False
+            return
 
         if result:
             return sublime.Region(pt + result.start(), pt + result.end())
-        else:
-            return False
 
     def find_next_count(self, count, pt):
         if count <= 0:
-            return False
+            return
 
         lr = self.view.line(pt)
         idx = pt + count
 
         if idx <= lr.b:
             return sublime.Region(idx, idx)
-        else:
-            return False
 
     def process_regions(self):
         sel = self.view.sel()
@@ -81,9 +75,8 @@ class JumpToBase(object):
             chars = groups[1]
             regex = groups[2]
         else:
-            count = None
+            count = regex = None
             chars = characters
-            regex = None
 
         sel = self.view.sel()
         self.regions = []
@@ -95,15 +88,13 @@ class JumpToBase(object):
             elif count:
                 new_reg = self.find_next_count(count, reg.b)
             else:
-                new_reg = False
-            if new_reg is not False:
+                new_reg = None
+            if new_reg is not None:
                 if self.extend:
                     end = new_reg.b if self.whole_selection else new_reg.a
                     new_reg = sublime.Region(reg.a, end)
                 elif not self.whole_selection:
                     new_reg = sublime.Region(new_reg.a, new_reg.a)
-            else:
-                new_reg = None
             self.regions.append((reg, new_reg))
 
 


### PR DESCRIPTION
I added two new features:
- **Create New Caret**: Instead of jumping with the current caret a new caret, this option will create a new caret at the target position
- **Whole Selection**: Use the selection provided by the search term, instead of only the starting position

In addition I slightly refactored the existing code.

Here is a demo to show the new features and eliminate ambiguities:
![jumptodemo](https://cloud.githubusercontent.com/assets/12573621/9703824/51492fa2-548f-11e5-80aa-325d93da13f4.gif)
